### PR TITLE
Fix for PayPal's update of requiring TLS 1.2 for all HTTPS connection…

### DIFF
--- a/Source/TeaCommerce.PaymentProviders/Classic/PayPal.cs
+++ b/Source/TeaCommerce.PaymentProviders/Classic/PayPal.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Web;
 using System.Web.Hosting;
@@ -105,6 +106,7 @@ namespace TeaCommerce.PaymentProviders.Classic {
         }
 
         //Verify callback
+        System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
         string response = MakePostRequest( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ? "https://www.sandbox.paypal.com/cgi-bin/webscr" : "https://www.paypal.com/cgi-bin/webscr", Encoding.ASCII.GetString( request.BinaryRead( request.ContentLength ) ) + "&cmd=_notify-validate" );
 
         if ( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ) {


### PR DESCRIPTION
Fix for PayPal's update of requiring TLS 1.2 for all HTTPS connections breaking the callback processing.
See our.umbraco.org/projects/website-utilities/tea-commerce/tea-commerce-support/75351-paypal-updates-with-teacommerce-1424
