### PR TITLE
V1 buttons fix for pay pal update of requiring tls 1.2 for all https connection

### DIFF
--- a/Source/TeaCommerce.PaymentProviders/PayPal.cs
+++ b/Source/TeaCommerce.PaymentProviders/PayPal.cs
@@ -181,6 +181,7 @@ namespace TeaCommerce.PaymentProviders {
       inputFields.Add( "CURRENCYCODE", order.CurrencyISOCode );
       inputFields.Add( "COMPLETETYPE", "Complete" );
 
+      System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
       Dictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( APIPostUrl, inputFields ) );
       if ( responseKvp[ "ACK" ].Equals( "Success" ) || responseKvp[ "ACK" ].Equals( "SuccessWithWarning" ) ) {
         return InternalGetStatus( responseKvp[ "TRANSACTIONID" ], settings );
@@ -199,6 +200,7 @@ namespace TeaCommerce.PaymentProviders {
 
       inputFields.Add( "TRANSACTIONID", order.TransactionPaymentTransactionId );
 
+      System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
       Dictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( APIPostUrl, inputFields ) );
       if ( responseKvp[ "ACK" ].Equals( "Success" ) || responseKvp[ "ACK" ].Equals( "SuccessWithWarning" ) ) {
         return InternalGetStatus( responseKvp[ "REFUNDTRANSACTIONID" ], settings );
@@ -217,6 +219,7 @@ namespace TeaCommerce.PaymentProviders {
 
       inputFields.Add( "AUTHORIZATIONID", order.TransactionPaymentTransactionId );
 
+      System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
       Dictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( APIPostUrl, inputFields ) );
       if ( responseKvp[ "ACK" ].Equals( "Success" ) || responseKvp[ "ACK" ].Equals( "SuccessWithWarning" ) ) {
         return InternalGetStatus( responseKvp[ "AUTHORIZATIONID" ], settings );
@@ -235,6 +238,7 @@ namespace TeaCommerce.PaymentProviders {
 
       inputFields.Add( "TRANSACTIONID", transactionId );
 
+      System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
       Dictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( APIPostUrl, inputFields ) );
       if ( responseKvp[ "ACK" ].Equals( "Success" ) || responseKvp[ "ACK" ].Equals( "SuccessWithWarning" ) ) {
 

--- a/Source/TeaCommerce.PaymentProviders/PayPal.cs
+++ b/Source/TeaCommerce.PaymentProviders/PayPal.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Web;
 using TeaCommerce.Data;
@@ -118,6 +119,7 @@ namespace TeaCommerce.PaymentProviders {
       isSandbox = settings[ "isSandbox" ] == "1";
 
       //Verify callback
+      System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
       string response = MakePostRequest( FormPostUrl, Encoding.ASCII.GetString( request.BinaryRead( request.ContentLength ) ) + "&cmd=_notify-validate" );
 
       //using ( StreamWriter writer = new StreamWriter( File.Create( HttpContext.Current.Server.MapPath( "~/PayPalTestCallback2.txt" ) ) ) ) {


### PR DESCRIPTION
Capture, Refund, Cancel & Status buttons fix for PayPal's update of requiring TLS 1.2 for all HTTPS connections.

See our.umbraco.org/projects/website-utilities/tea-commerce/tea-commerce-support/75351-paypal-updates-with-teacommerce-1424
