### PR TITLE
V2 buttons fix for pay pal update of requiring tls 1.2 for all https connection

### DIFF
--- a/Source/TeaCommerce.PaymentProviders/Classic/PayPal.cs
+++ b/Source/TeaCommerce.PaymentProviders/Classic/PayPal.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Web;
 using System.Web.Hosting;
@@ -136,6 +137,7 @@ namespace TeaCommerce.PaymentProviders.Classic {
         }
 
         //Verify callback
+        System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
         string response = MakePostRequest( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ? "https://www.sandbox.paypal.com/cgi-bin/webscr" : "https://www.paypal.com/cgi-bin/webscr", Encoding.ASCII.GetString( request.BinaryRead( request.ContentLength ) ) + "&cmd=_notify-validate" );
 
         if ( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ) {

--- a/Source/TeaCommerce.PaymentProviders/Classic/PayPal.cs
+++ b/Source/TeaCommerce.PaymentProviders/Classic/PayPal.cs
@@ -218,6 +218,7 @@ namespace TeaCommerce.PaymentProviders.Classic {
         inputFields.Add( "CURRENCYCODE", currency.IsoCode );
         inputFields.Add( "COMPLETETYPE", "Complete" );
 
+        System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
         IDictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ? "https://api-3t.sandbox.paypal.com/nvp" : "https://api-3t.paypal.com/nvp", inputFields ) );
         if ( responseKvp[ "ACK" ] == "Success" || responseKvp[ "ACK" ] == "SuccessWithWarning" ) {
           apiInfo = InternalGetStatus( order.OrderNumber, responseKvp[ "TRANSACTIONID" ], settings );
@@ -242,6 +243,7 @@ namespace TeaCommerce.PaymentProviders.Classic {
 
         inputFields.Add( "TRANSACTIONID", order.TransactionInformation.TransactionId );
 
+        System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
         IDictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ? "https://api-3t.sandbox.paypal.com/nvp" : "https://api-3t.paypal.com/nvp", inputFields ) );
         if ( responseKvp[ "ACK" ] == "Success" || responseKvp[ "ACK" ] == "SuccessWithWarning" ) {
           apiInfo = InternalGetStatus( order.OrderNumber, responseKvp[ "REFUNDTRANSACTIONID" ], settings );
@@ -266,6 +268,7 @@ namespace TeaCommerce.PaymentProviders.Classic {
 
         inputFields.Add( "AUTHORIZATIONID", order.TransactionInformation.TransactionId );
 
+        System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
         IDictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ? "https://api-3t.sandbox.paypal.com/nvp" : "https://api-3t.paypal.com/nvp", inputFields ) );
         if ( responseKvp[ "ACK" ] == "Success" || responseKvp[ "ACK" ] == "SuccessWithWarning" ) {
           apiInfo = InternalGetStatus( order.OrderNumber, responseKvp[ "AUTHORIZATIONID" ], settings );
@@ -303,6 +306,7 @@ namespace TeaCommerce.PaymentProviders.Classic {
 
       inputFields.Add( "TRANSACTIONID", transactionId );
 
+      System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
       IDictionary<string, string> responseKvp = GetApiResponseKvp( MakePostRequest( settings.ContainsKey( "isSandbox" ) && settings[ "isSandbox" ] == "1" ? "https://api-3t.sandbox.paypal.com/nvp" : "https://api-3t.paypal.com/nvp", inputFields ) );
       if ( responseKvp[ "ACK" ] == "Success" || responseKvp[ "ACK" ] == "SuccessWithWarning" ) {
 


### PR DESCRIPTION
Capture, Refund, Cancel & Status buttons fix for PayPal's update of requiring TLS 1.2 for all HTTPS connections.

See our.umbraco.org/projects/website-utilities/tea-commerce/tea-commerce-support/75351-paypal-updates-with-teacommerce-1424
