### PR TITLE
Fix for #16 rounding issues in Stripe Provider

### DIFF
--- a/Source/TeaCommerce.PaymentProviders.UnitTests/Helpers/PriceValueConverterTests.cs
+++ b/Source/TeaCommerce.PaymentProviders.UnitTests/Helpers/PriceValueConverterTests.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TeaCommerce.Api.Models;
+using TeaCommerce.PaymentProviders.Helpers;
+
+namespace TeaCommerce.PaymentProviders.UnitTests.Helpers
+{
+    [TestClass]
+    public class PriceValueConverterTests
+    {
+        #region ToCents Tests
+
+        [TestMethod]
+        public void ToCentsShouldConvertValueToCents()
+        {
+            var price = new Price(1.44M, 0M, 1.44M, new Currency() { Name = "GBP", CultureName = "en-GB" });
+            var fromPrice = price.FormattedWithoutSymbol.Replace(".", string.Empty);
+            var actual = price.Value.ToCents();
+
+            Assert.AreEqual(144, actual);
+            Assert.AreEqual(fromPrice, actual.ToString());
+        }
+
+        [TestMethod]
+        public void ToCentsShouldRoundUpHalfCentForEvenCentAmounts()
+        {
+            var price = new Price(1.445M, 0M, 1.445M, new Currency() { Name = "GBP", CultureName = "en-GB" });
+            var fromPrice = price.FormattedWithoutSymbol.Replace(".", string.Empty);
+            var actual = price.Value.ToCents();
+
+            Assert.AreEqual(145, actual);
+            Assert.AreEqual(fromPrice, actual.ToString());
+        }
+
+        [TestMethod]
+        public void ToCentsShouldRoundUpHalfCentForOddCentAmounts()
+        {
+            var price = new Price(1.455M, 0M, 1.455M, new Currency() { Name = "GBP", CultureName = "en-GB" });
+            var fromPrice = price.FormattedWithoutSymbol.Replace(".", string.Empty);
+            var actual = price.Value.ToCents();
+
+            Assert.AreEqual(146, actual);
+            Assert.AreEqual(fromPrice, actual.ToString());
+        }
+
+        [TestMethod]
+        public void ToCentsShouldRoundDown()
+        {
+            var price = new Price(1.454M, 0M, 1.454M, new Currency() { Name = "GBP", CultureName = "en-GB" });
+            var fromPrice = price.FormattedWithoutSymbol.Replace(".", string.Empty);
+            var actual = price.Value.ToCents();
+
+            Assert.AreEqual(145, actual);
+            Assert.AreEqual(fromPrice, actual.ToString());
+        }
+
+        [TestMethod]
+        public void ToCentsShouldRoundUp()
+        {
+            var price = new Price(1.456M, 0M, 1.456M, new Currency() { Name = "GBP", CultureName = "en-GB" });
+            var fromPrice = price.FormattedWithoutSymbol.Replace(".", string.Empty);
+            var actual = price.Value.ToCents();
+
+            Assert.AreEqual(146, actual);
+            Assert.AreEqual(fromPrice, actual.ToString());
+        }
+
+        #endregion
+    }
+}

--- a/Source/TeaCommerce.PaymentProviders.UnitTests/Properties/AssemblyInfo.cs
+++ b/Source/TeaCommerce.PaymentProviders.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TeaCommerce.PaymentProviders.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TeaCommerce.PaymentProviders.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("24fa88c4-abe8-4a6c-a587-aaae3f5191a1")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/TeaCommerce.PaymentProviders.UnitTests/TeaCommerce.PaymentProviders.UnitTests.csproj
+++ b/Source/TeaCommerce.PaymentProviders.UnitTests/TeaCommerce.PaymentProviders.UnitTests.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{24FA88C4-ABE8-4A6C-A587-AAAE3F5191A1}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TeaCommerce.PaymentProviders.UnitTests</RootNamespace>
+    <AssemblyName>TeaCommerce.PaymentProviders.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="TeaCommerce.Api">
+      <HintPath>..\Lib\Tea Commerce\TeaCommerce.Api.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Helpers\PriceValueConverterTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TeaCommerce.PaymentProviders\TeaCommerce.PaymentProviders.csproj">
+      <Project>{4CED9A0A-7669-43E8-8AAF-35D12EC4F002}</Project>
+      <Name>TeaCommerce.PaymentProviders</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/TeaCommerce.PaymentProviders.sln
+++ b/Source/TeaCommerce.PaymentProviders.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeaCommerce.PaymentProviders.Web", "TeaCommerce.PaymentProviders\TeaCommerce.PaymentProviders.csproj", "{4CED9A0A-7669-43E8-8AAF-35D12EC4F002}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeaCommerce.PaymentProviders", "TeaCommerce.PaymentProviders\TeaCommerce.PaymentProviders.csproj", "{4CED9A0A-7669-43E8-8AAF-35D12EC4F002}"
 EndProject
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "TeaCommerce.PaymentProviders.UI", "http://localhost:56791", "{7F142543-1476-4166-A88B-C4C9AB960616}"
 	ProjectSection(WebsiteProperties) = preProject
@@ -24,6 +24,8 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "TeaCommerce.PaymentProvider
 		SlnRelativePath = "TeaCommerce.PaymentProviders.UI\"
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeaCommerce.PaymentProviders.UnitTests", "TeaCommerce.PaymentProviders.UnitTests\TeaCommerce.PaymentProviders.UnitTests.csproj", "{24FA88C4-ABE8-4A6C-A587-AAAE3F5191A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{7F142543-1476-4166-A88B-C4C9AB960616}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F142543-1476-4166-A88B-C4C9AB960616}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{7F142543-1476-4166-A88B-C4C9AB960616}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{24FA88C4-ABE8-4A6C-A587-AAAE3F5191A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24FA88C4-ABE8-4A6C-A587-AAAE3F5191A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24FA88C4-ABE8-4A6C-A587-AAAE3F5191A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24FA88C4-ABE8-4A6C-A587-AAAE3F5191A1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/TeaCommerce.PaymentProviders/Helpers/PriceValueConverter.cs
+++ b/Source/TeaCommerce.PaymentProviders/Helpers/PriceValueConverter.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeaCommerce.PaymentProviders.Helpers
+{
+    public static class PriceValueConverter
+    {
+        public static int ToCents(this decimal value)
+        {
+            return (int)Math.Round(value * 100M, MidpointRounding.AwayFromZero);            
+        }
+    }
+}

--- a/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
@@ -11,6 +11,7 @@ using TeaCommerce.Api.Infrastructure.Logging;
 using TeaCommerce.Api.Models;
 using TeaCommerce.Api.Services;
 using TeaCommerce.Api.Web.PaymentProviders;
+using TeaCommerce.PaymentProviders.Helpers;
 
 namespace TeaCommerce.PaymentProviders.Inline {
   [PaymentProvider( "Stripe - inline" )]
@@ -121,7 +122,7 @@ namespace TeaCommerce.PaymentProviders.Inline {
         }
 
         StripeChargeCreateOptions chargeOptions = new StripeChargeCreateOptions {
-          AmountInCents = (int)( order.TotalPrice.Value.WithVat * 100 ),
+          AmountInCents = order.TotalPrice.Value.WithVat.ToCents(),
           Currency = CurrencyService.Instance.Get( order.StoreId, order.CurrencyId ).IsoCode,
           TokenId = request.Form[ "stripeToken" ],
           Description = order.CartNumber,
@@ -226,7 +227,7 @@ namespace TeaCommerce.PaymentProviders.Inline {
         settings.MustContainKey( settings[ "mode" ] + "_secret_key", "settings" );
 
         StripeChargeService chargeService = new StripeChargeService( settings[ settings[ "mode" ] + "_secret_key" ] );
-        StripeCharge charge = chargeService.Capture( order.TransactionInformation.TransactionId, (int)order.TransactionInformation.AmountAuthorized.Value * 100 );
+        StripeCharge charge = chargeService.Capture( order.TransactionInformation.TransactionId, order.TransactionInformation.AmountAuthorized.Value.ToCents());
 
         return new ApiInfo( charge.Id, GetPaymentState( charge ) );
       } catch ( Exception exp ) {

--- a/Source/TeaCommerce.PaymentProviders/TeaCommerce.PaymentProviders.csproj
+++ b/Source/TeaCommerce.PaymentProviders/TeaCommerce.PaymentProviders.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Classic\Invoicing.cs" />
     <Compile Include="Classic\QuickPay10.cs" />
     <Compile Include="Classic\Paynova.cs" />
+    <Compile Include="Helpers\PriceValueConverter.cs" />
     <Compile Include="Inline\Klarna.cs" />
     <Compile Include="Inline\CyberSource.cs" />
     <Compile Include="Classic\PaymentSense.cs" />


### PR DESCRIPTION
Fix for #16 
As this issue looks like it affects other payment providers I have created a helper class `PriceValueConverter.cs` which contains a `ToCents` extension method which can be used in other payment providers.
This method uses `Math.Round` with `MidpointRounding.AwayFromZero` rounding to match the behavior of the Price Formatting methods.

I have updated the Stripe payment provider to use the new `ToCents` method and added unit tests to illustrate the bug.
