### PR TITLE
Stripe Subscription payment provider

### DIFF
--- a/Source/TeaCommerce.PaymentProviders/Inline/BaseStripeProvider.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/BaseStripeProvider.cs
@@ -18,7 +18,7 @@ namespace TeaCommerce.PaymentProviders.Inline
 
         public override bool FinalizeAtContinueUrl { get { return true; } }
 
-        public IDictionary<string, string> BaseDefaultSettings
+        public override IDictionary<string, string> DefaultSettings
         {
             get
             {

--- a/Source/TeaCommerce.PaymentProviders/Inline/BaseStripeProvider.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/BaseStripeProvider.cs
@@ -1,0 +1,207 @@
+﻿using Stripe;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Web;
+using TeaCommerce.Api.Common;
+using TeaCommerce.Api.Services;
+using TeaCommerce.Api.Web.PaymentProviders;
+using Order = TeaCommerce.Api.Models.Order;
+
+namespace TeaCommerce.PaymentProviders.Inline
+{
+    public abstract class BaseStripeProvider : APaymentProvider
+    {
+        public override string DocumentationLink { get { return "https://stripe.com/docs"; } }
+
+        public override bool FinalizeAtContinueUrl { get { return true; } }
+
+        public IDictionary<string, string> BaseDefaultSettings
+        {
+            get
+            {
+                return new Dictionary<string, string> {
+                    { "form_url", "" },
+                    { "continue_url", "" },
+                    { "cancel_url", "" },
+                    { "billing_address_line1_property_alias", "streetAddress" },
+                    { "billing_address_line2_property_alias", "" },
+                    { "billing_city_property_alias", "city" },
+                    { "billing_state_property_alias", "" },
+                    { "billing_zip_code_property_alias", "zipCode" },
+                    { "test_secret_key", "" },
+                    { "test_public_key", "" },
+                    { "live_secret_key", "" },
+                    { "live_public_key", "" },
+                    { "mode", "test" },
+                };
+            }
+        }
+
+        public override PaymentHtmlForm GenerateHtmlForm(Order order, string teaCommerceContinueUrl, string teaCommerceCancelUrl, string teaCommerceCallBackUrl, string teaCommerceCommunicationUrl, IDictionary<string, string> settings)
+        {
+            order.MustNotBeNull("order");
+            settings.MustNotBeNull("settings");
+            settings.MustContainKey("form_url", "settings");
+            settings.MustContainKey("mode", "settings");
+            settings.MustContainKey(settings["mode"] + "_public_key", "settings");
+
+            var htmlForm = new PaymentHtmlForm
+            {
+                Action = settings["form_url"]
+            };
+
+            // Copy all settings except those in default settings list
+            // as all default settings are handled explicitly below
+            htmlForm.InputFields = settings.Where(i => !DefaultSettings.ContainsKey(i.Key)).ToDictionary(i => i.Key, i => i.Value);
+
+            htmlForm.InputFields["api_key"] = settings[settings["mode"] + "_public_key"];
+            htmlForm.InputFields["continue_url"] = teaCommerceContinueUrl;
+            htmlForm.InputFields["cancel_url"] = teaCommerceCancelUrl;
+
+            if (settings.ContainsKey("billing_address_line1_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_address_line1_property_alias"]))
+                htmlForm.InputFields["billing_address_line1"] = order.Properties.First(x => x.Alias == settings["billing_address_line1_property_alias"]).Value;
+
+            if (settings.ContainsKey("billing_address_line2_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_address_line2_property_alias"]))
+                htmlForm.InputFields["billing_address_line2"] = order.Properties.First(x => x.Alias == settings["billing_address_line2_property_alias"]).Value;
+
+            if (settings.ContainsKey("billing_city_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_city_property_alias"]))
+                htmlForm.InputFields["billing_city"] = order.Properties.First(x => x.Alias == settings["billing_city_property_alias"]).Value;
+
+            if (settings.ContainsKey("billing_state_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_state_property_alias"]))
+                htmlForm.InputFields["billing_state"] = order.Properties.First(x => x.Alias == settings["billing_state_property_alias"]).Value;
+
+            if (settings.ContainsKey("billing_zip_code_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_zip_code_property_alias"]))
+                htmlForm.InputFields["billing_zip_code"] = order.Properties.First(x => x.Alias == settings["billing_zip_code_property_alias"]).Value;
+
+            if (order.PaymentInformation != null && order.PaymentInformation.CountryId > 0)
+            {
+                var country = CountryService.Instance.Get(order.StoreId, order.PaymentInformation.CountryId);
+                htmlForm.InputFields["billing_country"] = country.RegionCode.ToLowerInvariant();
+            }
+
+            return htmlForm;
+        }
+
+        public override string GetContinueUrl(Order order, IDictionary<string, string> settings)
+        {
+            settings.MustNotBeNull("settings");
+            settings.MustContainKey("continue_url", "settings");
+
+            return settings["continue_url"];
+        }
+
+        public override string GetCancelUrl(Order order, IDictionary<string, string> settings)
+        {
+            settings.MustNotBeNull("settings");
+            settings.MustContainKey("cancel_url", "settings");
+
+            return settings["cancel_url"];
+        }
+
+        public override string GetLocalizedSettingsKey(string settingsKey, CultureInfo culture)
+        {
+            switch (settingsKey)
+            {
+                case "form_url":
+                    return settingsKey + "<br/><small>The url of the page with the Stripe payment form on - e.g. /payment/</small>";
+                case "continue_url":
+                    return settingsKey + "<br/><small>The url to navigate to after payment is processed - e.g. /confirmation/</small>";
+                case "cancel_url":
+                    return settingsKey + "<br/><small>The url to navigate to if the customer cancels the payment - e.g. /cancel/</small>";
+                case "billing_address_line1_property_alias":
+                    return settingsKey + "<br/><small>The alias of the property containing line 1 of the billing address - e.g. addressLine1. Used by Stripe for Radar verification.</small>";
+                case "billing_address_line2_property_alias":
+                    return settingsKey + "<br/><small>The alias of the property containing line 2 of the billing address - e.g. addressLine2. Used by Stripe for Radar verification.</small>";
+                case "billing_city_property_alias":
+                    return settingsKey + "<br/><small>The alias of the property containing the billing address city - e.g. city. Used by Stripe for Radar verification.</small>";
+                case "billing_state_property_alias":
+                    return settingsKey + "<br/><small>The alias of the property containing the billing address state - e.g. state. Used by Stripe for Radar verification.</small>";
+                case "billing_zip_code_property_alias":
+                    return settingsKey + "<br/><small>The alias of the property containing the billing address zip code - e.g. zipCode. Used by Stripe for Radar verification.</small>";
+                case "test_secret_key":
+                    return settingsKey + "<br/><small>Your test stripe secret key.</small>";
+                case "test_public_key":
+                    return settingsKey + "<br/><small>Your test stripe public key.</small>";
+                case "live_secret_key":
+                    return settingsKey + "<br/><small>Your live stripe secret key.</small>";
+                case "live_public_key":
+                    return settingsKey + "<br/><small>Your live stripe public key.</small>";
+                case "mode":
+                    return settingsKey + "<br/><small>The mode of the provider - test/live.</small>";
+                default:
+                    return base.GetLocalizedSettingsKey(settingsKey, culture);
+            }
+        }
+
+        protected void ReturnToPaymentFormWithException(Order order, HttpRequest request, StripeException e)
+        {
+            // Pass through request fields
+            var requestFields = string.Join("", request.Form.AllKeys.Select(k => "<input type=\"hidden\" name=\"" + k + "\" value=\"" + request.Form[k] + "\" />"));
+
+            //Add error details from the exception.
+            requestFields = requestFields + "<input type=\"hidden\" name=\"TransactionFailed\" value=\"true\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.chargeId\" value=\"" + e.StripeError.ChargeId + "\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Code\" value=\"" + e.StripeError.Code + "\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Error\" value=\"" + e.StripeError.Error + "\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.ErrorDescription\" value=\"" + e.StripeError.ErrorDescription + "\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.ErrorType\" value=\"" + e.StripeError.ErrorType + "\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Message\" value=\"" + e.StripeError.Message + "\" />";
+            requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Parameter\" value=\"" + e.StripeError.Parameter + "\" />";
+
+            var paymentForm = PaymentMethodService.Instance.Get(order.StoreId, order.PaymentInformation.PaymentMethodId.Value).GeneratePaymentForm(order, requestFields);
+
+            //Force the form to auto submit
+            paymentForm += "<script type=\"text/javascript\">document.forms[0].submit();</script>";
+
+            //Write out the form
+            HttpContext.Current.Response.Clear();
+            HttpContext.Current.Response.Write(paymentForm);
+            HttpContext.Current.Response.End();
+        }
+
+        protected Event GetStripeEvent(HttpRequest request)
+        {
+            Event stripeEvent = null;
+
+            if (HttpContext.Current.Items["TC_StripeEvent"] != null)
+            {
+                stripeEvent = (Event)HttpContext.Current.Items["TC_StripeEvent"];
+            }
+            else
+            {
+                try
+                {
+                    if (request.InputStream.CanSeek)
+                    {
+                        request.InputStream.Seek(0, SeekOrigin.Begin);
+                    }
+
+                    using (StreamReader reader = new StreamReader(request.InputStream))
+                    {
+                        stripeEvent = EventUtility.ParseEvent(reader.ReadToEnd());
+
+                        HttpContext.Current.Items["TC_StripeEvent"] = stripeEvent;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            return stripeEvent;
+        }
+
+        protected static long DollarsToCents(decimal val)
+        {
+            return (long)Math.Round(val * 100M, MidpointRounding.AwayFromZero);
+        }
+
+        protected static decimal CentsToDollars(long val)
+        {
+            return (decimal)val / 100;
+        }
+    }
+}

--- a/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
@@ -26,7 +26,7 @@ namespace TeaCommerce.PaymentProviders.Inline
         {
             get
             {
-                return BaseDefaultSettings
+                return base.DefaultSettings
                     .Union(new Dictionary<string, string> {
                         { "capture", "false" }
                     })

--- a/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
@@ -16,111 +16,23 @@ using Order = TeaCommerce.Api.Models.Order;
 namespace TeaCommerce.PaymentProviders.Inline
 {
     [PaymentProvider("Stripe - inline")]
-    public class Stripe : APaymentProvider
+    public class Stripe : BaseStripeProvider
     {
-        public override string DocumentationLink { get { return "https://stripe.com/docs"; } }
-
         public override bool SupportsRetrievalOfPaymentStatus { get { return true; } }
         public override bool SupportsCapturingOfPayment { get { return true; } }
         public override bool SupportsRefundOfPayment { get { return true; } }
         public override bool SupportsCancellationOfPayment { get { return true; } }
 
-        public override bool FinalizeAtContinueUrl { get { return true; } }
-
         public override IDictionary<string, string> DefaultSettings
         {
             get
             {
-                return new Dictionary<string, string> {
-                    { "form_url", "" },
-                    { "continue_url", "" },
-                    { "cancel_url", "" },
-                    { "capture", "false" },
-                    { "billing_address_line1_property_alias", "streetAddress" },
-                    { "billing_address_line2_property_alias", "" },
-                    { "billing_city_property_alias", "city" },
-                    { "billing_state_property_alias", "" },
-                    { "billing_zip_code_property_alias", "zipCode" },
-                    { "test_secret_key", "" },
-                    { "test_public_key", "" },
-                    { "live_secret_key", "" },
-                    { "live_public_key", "" },
-                    { "mode", "test" },
-                };
+                return BaseDefaultSettings
+                    .Union(new Dictionary<string, string> {
+                        { "capture", "false" }
+                    })
+                    .ToDictionary(k => k.Key, v => v.Value);
             }
-        }
-
-        public override PaymentHtmlForm GenerateHtmlForm(Order order, string teaCommerceContinueUrl, string teaCommerceCancelUrl, string teaCommerceCallBackUrl, string teaCommerceCommunicationUrl, IDictionary<string, string> settings)
-        {
-            order.MustNotBeNull("order");
-            settings.MustNotBeNull("settings");
-            settings.MustContainKey("form_url", "settings");
-            settings.MustContainKey("mode", "settings");
-            settings.MustContainKey(settings["mode"] + "_public_key", "settings");
-
-            var htmlForm = new PaymentHtmlForm {
-                Action = settings["form_url"]
-            };
-
-            var settingsToExclude = new[] {
-                "form_url",
-                "capture",
-                "billing_address_line1_property_alias",
-                "billing_address_line2_property_alias",
-                "billing_city_property_alias",
-                "billing_state_property_alias",
-                "billing_zip_code_property_alias",
-                "test_secret_key",
-                "test_public_key",
-                "live_secret_key",
-                "live_public_key",
-                "mode"
-            };
-
-            htmlForm.InputFields = settings.Where(i => !settingsToExclude.Contains(i.Key)).ToDictionary(i => i.Key, i => i.Value);
-
-            htmlForm.InputFields["api_key"] = settings[settings["mode"] + "_public_key"];
-            htmlForm.InputFields["continue_url"] = teaCommerceContinueUrl;
-            htmlForm.InputFields["cancel_url"] = teaCommerceCancelUrl;
-
-            if (settings.ContainsKey("billing_address_line1_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_address_line1_property_alias"]))
-                htmlForm.InputFields["billing_address_line1"] = order.Properties.First(x => x.Alias == settings["billing_address_line1_property_alias"]).Value;
-
-            if (settings.ContainsKey("billing_address_line2_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_address_line2_property_alias"]))
-                htmlForm.InputFields["billing_address_line2"] = order.Properties.First(x => x.Alias == settings["billing_address_line2_property_alias"]).Value;
-
-            if (settings.ContainsKey("billing_city_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_city_property_alias"]))
-                htmlForm.InputFields["billing_city"] = order.Properties.First(x => x.Alias == settings["billing_city_property_alias"]).Value;
-
-            if (settings.ContainsKey("billing_state_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_state_property_alias"]))
-                htmlForm.InputFields["billing_state"] = order.Properties.First(x => x.Alias == settings["billing_state_property_alias"]).Value;
-
-            if (settings.ContainsKey("billing_zip_code_property_alias") && !string.IsNullOrWhiteSpace(settings["billing_zip_code_property_alias"]))
-                htmlForm.InputFields["billing_zip_code"] = order.Properties.First(x => x.Alias == settings["billing_zip_code_property_alias"]).Value;
-
-            if (order.PaymentInformation != null && order.PaymentInformation.CountryId > 0)
-            {
-                var country = CountryService.Instance.Get(order.StoreId, order.PaymentInformation.CountryId);
-                htmlForm.InputFields["billing_country"] = country.RegionCode.ToLowerInvariant();
-            }
-
-            return htmlForm;
-        }
-
-        public override string GetContinueUrl(Order order, IDictionary<string, string> settings)
-        {
-            settings.MustNotBeNull("settings");
-            settings.MustContainKey("continue_url", "settings");
-
-            return settings["continue_url"];
-        }
-
-        public override string GetCancelUrl(Order order, IDictionary<string, string> settings)
-        {
-            settings.MustNotBeNull("settings");
-            settings.MustContainKey("cancel_url", "settings");
-
-            return settings["cancel_url"];
         }
 
         public override string GetCartNumber(HttpRequest request, IDictionary<string, string> settings)
@@ -219,28 +131,7 @@ namespace TeaCommerce.PaymentProviders.Inline
             }
             catch (StripeException e)
             {
-                // Pass through request fields
-                var requestFields = string.Join("", request.Form.AllKeys.Select(k => "<input type=\"hidden\" name=\"" + k + "\" value=\"" + request.Form[k] + "\" />"));
-
-                //Add error details from the exception.
-                requestFields = requestFields + "<input type=\"hidden\" name=\"TransactionFailed\" value=\"true\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.chargeId\" value=\"" + e.StripeError.ChargeId + "\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Code\" value=\"" + e.StripeError.Code + "\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Error\" value=\"" + e.StripeError.Error + "\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.ErrorDescription\" value=\"" + e.StripeError.ErrorDescription + "\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.ErrorType\" value=\"" + e.StripeError.ErrorType + "\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Message\" value=\"" + e.StripeError.Message + "\" />";
-                requestFields = requestFields + "<input type=\"hidden\" name=\"FailureReason.Parameter\" value=\"" + e.StripeError.Parameter + "\" />";
-
-                var paymentForm = PaymentMethodService.Instance.Get(order.StoreId, order.PaymentInformation.PaymentMethodId.Value).GeneratePaymentForm(order, requestFields);
-
-                //Force the form to auto submit
-                paymentForm += "<script type=\"text/javascript\">document.forms[0].submit();</script>";
-
-                //Write out the form
-                HttpContext.Current.Response.Clear();
-                HttpContext.Current.Response.Write(paymentForm);
-                HttpContext.Current.Response.End();
+                ReturnToPaymentFormWithException(order, request, e);
             }
             catch (Exception exp)
             {
@@ -389,34 +280,8 @@ namespace TeaCommerce.PaymentProviders.Inline
         {
             switch (settingsKey)
             {
-                case "form_url":
-                    return settingsKey + "<br/><small>The url of the page with the Stripe payment form on - e.g. /payment/</small>";
-                case "continue_url":
-                    return settingsKey + "<br/><small>The url to navigate to after payment is processed - e.g. /confirmation/</small>";
-                case "cancel_url":
-                    return settingsKey + "<br/><small>The url to navigate to if the customer cancels the payment - e.g. /cancel/</small>";
                 case "capture":
                     return settingsKey + "<br/><small>Flag indicating if a payment should be captured instantly - true/false.</small>";
-                case "billing_address_line1_property_alias":
-                    return settingsKey + "<br/><small>The alias of the property containing line 1 of the billing address - e.g. addressLine1. Used by Stripe for Radar verification.</small>";
-                case "billing_address_line2_property_alias":
-                    return settingsKey + "<br/><small>The alias of the property containing line 2 of the billing address - e.g. addressLine2. Used by Stripe for Radar verification.</small>";
-                case "billing_city_property_alias":
-                    return settingsKey + "<br/><small>The alias of the property containing the billing address city - e.g. city. Used by Stripe for Radar verification.</small>";
-                case "billing_state_property_alias":
-                    return settingsKey + "<br/><small>The alias of the property containing the billing address state - e.g. state. Used by Stripe for Radar verification.</small>";
-                case "billing_zip_code_property_alias":
-                    return settingsKey + "<br/><small>The alias of the property containing the billing address zip code - e.g. zipCode. Used by Stripe for Radar verification.</small>";
-                case "test_secret_key":
-                    return settingsKey + "<br/><small>Your test stripe secret key.</small>";
-                case "test_public_key":
-                    return settingsKey + "<br/><small>Your test stripe public key.</small>";
-                case "live_secret_key":
-                    return settingsKey + "<br/><small>Your live stripe secret key.</small>";
-                case "live_public_key":
-                    return settingsKey + "<br/><small>Your live stripe public key.</small>";
-                case "mode":
-                    return settingsKey + "<br/><small>The mode of the provider - test/live.</small>";
                 default:
                     return base.GetLocalizedSettingsKey(settingsKey, culture);
             }
@@ -449,48 +314,6 @@ namespace TeaCommerce.PaymentProviders.Inline
             }
 
             return paymentState;
-        }
-
-        protected Event GetStripeEvent(HttpRequest request)
-        {
-            Event stripeEvent = null;
-
-            if (HttpContext.Current.Items["TC_StripeEvent"] != null)
-            {
-                stripeEvent = (Event)HttpContext.Current.Items["TC_StripeEvent"];
-            }
-            else
-            {
-                try
-                {
-                    if (request.InputStream.CanSeek)
-                    {
-                        request.InputStream.Seek(0, SeekOrigin.Begin);
-                    }
-
-                    using (StreamReader reader = new StreamReader(request.InputStream))
-                    {
-                        stripeEvent = EventUtility.ParseEvent(reader.ReadToEnd());
-
-                        HttpContext.Current.Items["TC_StripeEvent"] = stripeEvent;
-                    }
-                }
-                catch
-                {
-                }
-            }
-
-            return stripeEvent;
-        }
-
-        private static long DollarsToCents(decimal val)
-        {
-            return (long)Math.Round(val * 100M, MidpointRounding.AwayFromZero);
-        }
-
-        private static decimal CentsToDollars(long val)
-        {
-            return (decimal)val / 100;
         }
     }
 }

--- a/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/Stripe.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Web;

--- a/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
@@ -140,13 +140,12 @@ namespace TeaCommerce.PaymentProviders.Inline
                     Billing = billingMode == "charge" 
                         ? Billing.ChargeAutomatically 
                         : Billing.SendInvoice,
-                    Items = order.OrderLines.Select(x => 
-                        new SubscriptionItemOption
-                        {
-                            PlanId = x.Sku,
-                            Quantity = (long)x.Quantity
-                        }
-                    ).ToList(),
+                    Items = order.OrderLines.Select(x => new SubscriptionItemOption {
+                        PlanId = !string.IsNullOrWhiteSpace(x.Properties["planId"])
+                            ? x.Properties["planId"]
+                            : x.Sku,
+                        Quantity = (long)x.Quantity
+                    }).ToList(),
                     Metadata = new Dictionary<string, string>
                     {
                         { "orderId", order.Id.ToString() },

--- a/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
@@ -1,0 +1,201 @@
+﻿using Stripe;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Web;
+using TeaCommerce.Api.Common;
+using TeaCommerce.Api.Infrastructure.Logging;
+using TeaCommerce.Api.Models;
+using TeaCommerce.Api.Services;
+using TeaCommerce.Api.Web.PaymentProviders;
+using Order = TeaCommerce.Api.Models.Order;
+
+namespace TeaCommerce.PaymentProviders.Inline
+{
+    [PaymentProvider("Stripe Subscription - inline")]
+    public class StripeSubscription : BaseStripeProvider
+    {
+        public override bool SupportsRetrievalOfPaymentStatus { get { return true; } }
+        public override bool SupportsCapturingOfPayment { get { return false; } }
+        public override bool SupportsRefundOfPayment { get { return false; } }
+        public override bool SupportsCancellationOfPayment { get { return false; } }
+
+        public override IDictionary<string, string> DefaultSettings
+        {
+            get
+            {
+                return BaseDefaultSettings;
+            }
+        }
+
+        public override string GetCartNumber(HttpRequest request, IDictionary<string, string> settings)
+        {
+            var cartNumber = "";
+
+            try
+            {
+                request.MustNotBeNull("request");
+                settings.MustNotBeNull("settings");
+
+                // If in test mode, write out the form data to a text file
+                if (settings.ContainsKey("mode") && settings["mode"] == "test")
+                {
+                    LogRequest<StripeSubscription>(request, logPostData: true);
+                }
+
+                // Get the current stripe api key based on mode
+                var apiKey = settings[settings["mode"] + "_secret_key"];
+
+                var stripeEvent = GetStripeEvent(request);
+
+                // We are only interested in charge events
+                if (stripeEvent != null && stripeEvent.Type.StartsWith("invoice."))
+                {
+                    var invoice = Mapper<Invoice>.MapFromJson(stripeEvent.Data.Object.ToString());
+                    if (!string.IsNullOrWhiteSpace(invoice.SubscriptionId))
+                    {
+                        var subscriptionService = new SubscriptionService(apiKey);
+                        var subscription = subscriptionService.Get(invoice.SubscriptionId);
+                        if (subscription?.Metadata != null && subscription.Metadata.ContainsKey("cartNumber"))
+                        {
+                            cartNumber = subscription.Metadata["cartNumber"];
+                        }
+                    }
+                }
+                else
+                {
+                    HttpContext.Current.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                }
+            }
+            catch (Exception exp)
+            {
+                LoggingService.Instance.Error<StripeSubscription>("StripeSubscription - GetCartNumber", exp);
+            }
+
+            return cartNumber;
+        }
+
+        public override CallbackInfo ProcessCallback(Order order, HttpRequest request, IDictionary<string, string> settings)
+        {
+            CallbackInfo callbackInfo = null;
+
+            try
+            {
+                order.MustNotBeNull("order");
+                request.MustNotBeNull("request");
+                settings.MustNotBeNull("settings");
+                settings.MustContainKey("mode", "settings");
+                settings.MustContainKey(settings["mode"] + "_secret_key", "settings");
+
+                // If in test mode, write out the form data to a text file
+                if (settings.ContainsKey("mode") && settings["mode"] == "test")
+                {
+                    LogRequest<StripeSubscription>(request, logPostData: true);
+                }
+
+                var apiKey = settings[settings["mode"] + "_secret_key"];
+                var capture = settings["capture"].TryParse<bool>() ?? false;
+
+                // Get the Plan ID from the order. As we can only process
+                // one subscription at a time, assume the first order item
+                // is the subscription product.
+                var planId = order.OrderLines.FirstOrDefault()?.Sku;
+
+                // Ensure we have a Plan ID
+                planId.MustNotBeNullOrEmpty("planId");
+
+                // Create the stripe customer
+                var customerService = new CustomerService(apiKey);
+                var customer = customerService.Create(new CustomerCreateOptions
+                {
+                    Email = order.PaymentInformation.Email,
+                    SourceToken = request.Form["stripeToken"]
+                });
+
+                // Subscribe customer to plan
+                var subscriptionService = new SubscriptionService(apiKey);
+                var subscription = subscriptionService.Create(new SubscriptionCreateOptions
+                {
+                    CustomerId = customer.Id,
+                    Items = new List<SubscriptionItemOption>
+                    {
+                        new SubscriptionItemOption
+                        {
+                            PlanId = planId,
+                            Quantity = 1
+                        }
+                    },
+                    Metadata = new Dictionary<string, string>
+                    {
+                        { "orderId", order.Id.ToString() },
+                        { "cartNumber", order.CartNumber }
+                    }
+                });
+
+                // Stash the stripe info in the order
+                order.Properties.AddOrUpdate("stripeCustomerId", customer.Id);
+                order.Properties.AddOrUpdate("stripeSubscriptionId", subscription.Id);
+                order.Save();
+
+                // Authorize the payment. We'll capture it on a successful webhook callback
+                callbackInfo = new CallbackInfo(CentsToDollars(subscription.Plan.Amount.Value), subscription.Id, PaymentState.Authorized);
+
+            }
+            catch (StripeException e)
+            {
+                ReturnToPaymentFormWithException(order, request, e);
+            }
+            catch (Exception exp)
+            {
+                LoggingService.Instance.Error<StripeSubscription>("StripeSubscription(" + order.CartNumber + ") - ProcessCallback", exp);
+            }
+
+            return callbackInfo;
+        }
+
+        public override string ProcessRequest(Order order, HttpRequest request, IDictionary<string, string> settings)
+        {
+            var response = "";
+
+            try
+            {
+                order.MustNotBeNull("order");
+                request.MustNotBeNull("request");
+                settings.MustNotBeNull("settings");
+
+                // If in test mode, write out the form data to a text file
+                if (settings.ContainsKey("mode") && settings["mode"] == "test")
+                {
+                    LogRequest<StripeSubscription>(request, logPostData: true);
+                }
+
+                // Stripe supports webhooks
+                var stripeEvent = GetStripeEvent(request);
+
+                // With subscriptions, Stripe creates an invoice for each payment
+                // so to ensure subscription is live, we'll listen for successful invoice payment
+                if (stripeEvent.Type.StartsWith("invoice."))
+                {
+                    var invoice = Mapper<Invoice>.MapFromJson(stripeEvent.Data.Object.ToString());
+
+                    if (stripeEvent.Type == "invoice.payment_succeeded"
+                        && order.TransactionInformation.PaymentState != PaymentState.Captured)
+                    {
+                        order.TransactionInformation.TransactionId = invoice.ChargeId;
+                        order.TransactionInformation.PaymentState = PaymentState.Captured;
+                        order.Save();
+                    }
+                }
+            }
+            catch (Exception exp)
+            {
+                LoggingService.Instance.Error<StripeSubscription>("StripeSubscription(" + order.CartNumber + ") - ProcessRequest", exp);
+            }
+
+            return response;
+        }
+    }
+}

--- a/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
@@ -1,15 +1,12 @@
 ﻿using Stripe;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Web;
 using TeaCommerce.Api.Common;
 using TeaCommerce.Api.Infrastructure.Logging;
 using TeaCommerce.Api.Models;
-using TeaCommerce.Api.Services;
 using TeaCommerce.Api.Web.PaymentProviders;
 using Order = TeaCommerce.Api.Models.Order;
 
@@ -18,7 +15,7 @@ namespace TeaCommerce.PaymentProviders.Inline
     [PaymentProvider("Stripe Subscription - inline")]
     public class StripeSubscription : BaseStripeProvider
     {
-        public override bool SupportsRetrievalOfPaymentStatus { get { return true; } }
+        public override bool SupportsRetrievalOfPaymentStatus { get { return false; } }
         public override bool SupportsCapturingOfPayment { get { return false; } }
         public override bool SupportsRefundOfPayment { get { return false; } }
         public override bool SupportsCancellationOfPayment { get { return false; } }

--- a/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
@@ -13,7 +13,7 @@ using Order = TeaCommerce.Api.Models.Order;
 
 namespace TeaCommerce.PaymentProviders.Inline
 {
-    [PaymentProvider("Stripe Subscription - inline")]
+    [PaymentProvider("StripeSubscription - inline")]
     public class StripeSubscription : BaseStripeProvider
     {
         public override bool SupportsRetrievalOfPaymentStatus { get { return false; } }
@@ -25,7 +25,7 @@ namespace TeaCommerce.PaymentProviders.Inline
         {
             get
             {
-                return BaseDefaultSettings
+                return base.DefaultSettings
                     .Union(new Dictionary<string, string> {
                         { "billing_mode", "charge" }
                     })

--- a/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
@@ -140,13 +140,13 @@ namespace TeaCommerce.PaymentProviders.Inline
                     Billing = billingMode == "charge" 
                         ? Billing.ChargeAutomatically 
                         : Billing.SendInvoice,
-                    Items = new List<SubscriptionItemOption>(order.OrderLines.Select(x =>
+                    Items = order.OrderLines.Select(x => 
                         new SubscriptionItemOption
                         {
                             PlanId = x.Sku,
                             Quantity = (long)x.Quantity
                         }
-                    )),
+                    ).ToList(),
                     Metadata = new Dictionary<string, string>
                     {
                         { "orderId", order.Id.ToString() },

--- a/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
+++ b/Source/TeaCommerce.PaymentProviders/Inline/StripeSubscription.cs
@@ -179,6 +179,8 @@ namespace TeaCommerce.PaymentProviders.Inline
                     var invoice = Mapper<Invoice>.MapFromJson(stripeEvent.Data.Object.ToString());
 
                     if (stripeEvent.Type == "invoice.payment_succeeded"
+                        && order.Properties["stripeCustomerId"] == invoice.CustomerId
+                        && order.Properties["stripeSubscriptionId"] == invoice.SubscriptionId
                         && order.TransactionInformation.PaymentState != PaymentState.Captured)
                     {
                         order.TransactionInformation.TransactionId = invoice.ChargeId;

--- a/Source/TeaCommerce.PaymentProviders/Properties/VersionInfo.cs
+++ b/Source/TeaCommerce.PaymentProviders/Properties/VersionInfo.cs
@@ -14,6 +14,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("3.0.*")]
-[assembly: AssemblyInformationalVersion("3.0.7-alpha+20190117.193042")]
+[assembly: AssemblyInformationalVersion("3.0.7-alpha+20190119.215442")]
 
 

--- a/Source/TeaCommerce.PaymentProviders/TeaCommerce.PaymentProviders.csproj
+++ b/Source/TeaCommerce.PaymentProviders/TeaCommerce.PaymentProviders.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Classic\Invoicing.cs" />
     <Compile Include="Classic\QuickPay10.cs" />
     <Compile Include="Classic\Paynova.cs" />
+    <Compile Include="Inline\BaseStripeProvider.cs" />
     <Compile Include="Inline\Klarna.cs" />
     <Compile Include="Inline\CyberSource.cs" />
     <Compile Include="Classic\PaymentSense.cs" />
@@ -93,6 +94,7 @@
     <Compile Include="Classic\Payer.cs" />
     <Compile Include="Classic\PayEx.cs" />
     <Compile Include="Classic\PayPal.cs" />
+    <Compile Include="Inline\StripeSubscription.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Classic\QuickPay.cs" />
     <Compile Include="Classic\SagePay.cs" />


### PR DESCRIPTION
Something I created for a client a while ago, but now that the main Stripe provider has been updated I thought I'd get this setup as a PR.

It's currently very specific, so I need to see if it can be a bit more flexible, but it currently assumes the Order contains a single order item (the plan) and then assumes the SKU property is the ID of the Plan setup in Stripe. Once processed, it creates a customer using the billing email, and then sets up the subscription in stripe. It then assumes the transaction is captured when notification of the first invoice payment comes through.

I don't know if it's possible to allow multiple items to be ordered (though who really orders multiple subscriptions).