### PR TITLE
Change Apply3DSecure default to 0 to reduce potential liability for c…

### DIFF
--- a/Source/TeaCommerce.PaymentProviders.SagePay/SagePay.cs
+++ b/Source/TeaCommerce.PaymentProviders.SagePay/SagePay.cs
@@ -155,7 +155,7 @@ namespace TeaCommerce.PaymentProviders.Classic
 
             if (!settings.ContainsKey("Apply3DSecure"))
             {
-                inputFields["Apply3DSecure"] = "2";
+                inputFields["Apply3DSecure"] = "0";
             }
 
             IDictionary<string, string> responseFields = GetFields(MakePostRequest(GetMethodUrl("PURCHASE", settings), inputFields));


### PR DESCRIPTION
…hargebacks

Set the Apply3DSecure to match the SagePay default value of 0. Having 2 as the default bypasses 3D secure verification and leaves the site owner liable for any chargebacks.

SagePay recommend you configure 3D-Secure verification to protect yourself against chargebacks
3D-Secure provides protection from chargebacks - the bank takes responsibility if 3D-Secure is used