### PR TITLE
Fixed callback bug with QuickPay10 and special danish chars

### DIFF
--- a/Source/TeaCommerce.PaymentProviders.QuickPay/QuickPay10.cs
+++ b/Source/TeaCommerce.PaymentProviders.QuickPay/QuickPay10.cs
@@ -149,7 +149,7 @@ namespace TeaCommerce.PaymentProviders.Classic
                 request.InputStream.Read(bytes, 0, bytes.Length);
                 request.InputStream.Position = 0;
 
-                string streamContent = Encoding.ASCII.GetString(bytes);
+                string streamContent = Encoding.UTF8.GetString(bytes);
 
                 Result result = JsonConvert.DeserializeObject<Result>(streamContent);
 


### PR DESCRIPTION
When a customer using a credit card issued to a person with a name including the special danish letter: æ, ø, or å the callback will fail the checksum.